### PR TITLE
Hotfix/email-token

### DIFF
--- a/src/main/java/com/inssider/api/common/config/security/JwtCodecConfig.java
+++ b/src/main/java/com/inssider/api/common/config/security/JwtCodecConfig.java
@@ -27,8 +27,8 @@ class JwtCodecConfig {
   @Bean
   public JwtDecoder jwtDecoder() {
     NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withPublicKey(getRSAPublicKey()).build();
-    jwtDecoder.setJwtValidator(
-        JwtValidators.createDefault()); // [ ] implement DelegatingOAuth2TokenValidator
+    // [ ] implement DelegatingOAuth2TokenValidator
+    jwtDecoder.setJwtValidator(JwtValidators.createDefault());
     return jwtDecoder;
   }
 

--- a/src/main/java/com/inssider/api/common/config/security/OAuth2ResourceServerSecurityConfig.java
+++ b/src/main/java/com/inssider/api/common/config/security/OAuth2ResourceServerSecurityConfig.java
@@ -67,7 +67,7 @@ class OAuth2ResourceServerSecurityConfig {
   private String[] publicGetPaths() {
     return new String[] {
       "/api/accounts",
-      "/api/accounts/{email}",
+      "/api/accounts/check",
       "/api/profiles",
       "/api/profiles/index",
       "/api/profiles/{id:[0-9]+}",

--- a/src/main/java/com/inssider/api/common/config/security/OAuth2ResourceServerSecurityConfig.java
+++ b/src/main/java/com/inssider/api/common/config/security/OAuth2ResourceServerSecurityConfig.java
@@ -3,15 +3,16 @@ package com.inssider.api.common.config.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -19,10 +20,10 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 class OAuth2ResourceServerSecurityConfig {
 
-  private final Converter<Jwt, AbstractAuthenticationToken> customConverter;
+  private final Converter<Jwt, JwtAuthenticationToken> customConverter;
 
   @Bean
-  @Order(1)
+  @Order(value = Ordered.HIGHEST_PRECEDENCE)
   public SecurityFilterChain publicPathsChain(HttpSecurity http) throws Exception {
     return http.securityMatchers(
             matchers ->
@@ -40,7 +41,7 @@ class OAuth2ResourceServerSecurityConfig {
   }
 
   @Bean
-  @Order(2)
+  @Order(value = Ordered.LOWEST_PRECEDENCE)
   public SecurityFilterChain protectedApiChain(HttpSecurity http) throws Exception {
     return http.securityMatchers(matchers -> matchers.requestMatchers("/api/**"))
         .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
@@ -69,11 +70,11 @@ class OAuth2ResourceServerSecurityConfig {
       "/api/accounts/{email}",
       "/api/profiles",
       "/api/profiles/index",
-      "/api/profiles/{id}",
+      "/api/profiles/{id:[0-9]+}",
       "/api/posts",
-      "/api/posts/{id}",
+      "/api/posts/{id:[0-9]+}",
       "/api/memes/sitemap",
-      "/api/comments/{id}",
+      "/api/comments/{id:[0-9]+}",
       "/api/categories"
     };
   }

--- a/src/main/java/com/inssider/api/common/model/AccountJwtAuthenticationToken.java
+++ b/src/main/java/com/inssider/api/common/model/AccountJwtAuthenticationToken.java
@@ -14,7 +14,7 @@ public class AccountJwtAuthenticationToken extends JwtAuthenticationToken {
   }
 
   @Override
-  public Account getPrincipal() {
-    return account;
+  public Object getPrincipal() {
+    return account == null ? super.getPrincipal() : account;
   }
 }

--- a/src/main/java/com/inssider/api/domains/account/AccountAuthenticator.java
+++ b/src/main/java/com/inssider/api/domains/account/AccountAuthenticator.java
@@ -1,8 +1,5 @@
 package com.inssider.api.domains.account;
 
-import com.inssider.api.common.Util;
-import com.inssider.api.domains.account.AccountDataTypes.AccountType;
-import com.inssider.api.domains.account.AccountDataTypes.RoleType;
 import com.inssider.api.domains.auth.code.AuthCodeService;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -38,15 +35,7 @@ public class AccountAuthenticator {
 
   public Account redeemAuthorizationCode(UUID authCodeId) {
     String email = authCodeService.redeem(authCodeId).getEmail();
-    return repository
-        .findByEmail(email)
-        .orElse(
-            Account.builder()
-                .accountType(AccountType.PASSWORD)
-                .role(RoleType.USER)
-                .email(email)
-                .password(Util.passwordGenerator().get())
-                .build());
+    return repository.findByEmail(email).orElse(Account.builder().email(email).build());
   }
 
   public Account getAccountFromToken(String token) throws NoSuchElementException {

--- a/src/main/java/com/inssider/api/domains/account/AccountAuthenticator.java
+++ b/src/main/java/com/inssider/api/domains/account/AccountAuthenticator.java
@@ -1,5 +1,6 @@
 package com.inssider.api.domains.account;
 
+import com.inssider.api.common.Util;
 import com.inssider.api.domains.account.AccountDataTypes.AccountType;
 import com.inssider.api.domains.account.AccountDataTypes.RoleType;
 import com.inssider.api.domains.auth.code.AuthCodeService;
@@ -44,6 +45,7 @@ public class AccountAuthenticator {
                 .accountType(AccountType.PASSWORD)
                 .role(RoleType.USER)
                 .email(email)
+                .password(Util.passwordGenerator().get())
                 .build());
   }
 

--- a/src/main/java/com/inssider/api/domains/account/AccountController.java
+++ b/src/main/java/com/inssider/api/domains/account/AccountController.java
@@ -6,7 +6,6 @@ import com.inssider.api.domains.account.AccountRequestsDto.PatchAccountPasswordR
 import com.inssider.api.domains.account.AccountRequestsDto.PostAccountRequest;
 import com.inssider.api.domains.account.AccountResponsesDto.PatchAccountMePasswordResponse;
 import com.inssider.api.domains.account.AccountResponsesDto.PostAccountResponse;
-import com.inssider.api.domains.auth.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController;
 class AccountController {
 
   private final AccountService service;
-  private final AuthService authService;
 
   @GetMapping("/check")
   ResponseEntity<ResponseWrapper<Void>> checkEmailAvailability(@RequestParam String email) {

--- a/src/main/java/com/inssider/api/domains/account/AccountController.java
+++ b/src/main/java/com/inssider/api/domains/account/AccountController.java
@@ -39,7 +39,7 @@ class AccountController {
   ResponseEntity<ResponseWrapper<PostAccountResponse>> register(
       // single_access token은 JWT.sub를 직접 활용해야 함
       @AuthenticationPrincipal Jwt jwt, @RequestBody PostAccountRequest reqBody) {
-    var email = jwt.getSubject();
+    var email = jwt.getClaimAsString("email");
     if (!email.equals(reqBody.email())) {
       throw new IllegalArgumentException("Email in request body must match authenticated email");
     }

--- a/src/main/java/com/inssider/api/domains/account/AccountController.java
+++ b/src/main/java/com/inssider/api/domains/account/AccountController.java
@@ -35,11 +35,9 @@ class AccountController {
   }
 
   @PostMapping
-  // @SecurityRequirement(name = "AccessToken")
   ResponseEntity<ResponseWrapper<PostAccountResponse>> register(
-      // single_access token은 JWT.sub를 직접 활용해야 함
       @AuthenticationPrincipal Jwt jwt, @RequestBody PostAccountRequest reqBody) {
-    var email = jwt.getClaimAsString("email");
+    String email = jwt.getClaim("email");
     if (!email.equals(reqBody.email())) {
       throw new IllegalArgumentException("Email in request body must match authenticated email");
     }

--- a/src/main/java/com/inssider/api/domains/auth/AuthController.java
+++ b/src/main/java/com/inssider/api/domains/auth/AuthController.java
@@ -74,7 +74,9 @@ class AuthController {
   @DeleteMapping("/token")
   public ResponseEntity<ResponseWrapper<Void>> revokeToken(
       @AuthenticationPrincipal Account account) {
-    authService.revokeRefreshToken(account);
+    if (account != null) {
+      authService.revokeRefreshToken(account);
+    }
     return BaseResponse.of(200, null);
   }
 }

--- a/src/main/java/com/inssider/api/domains/auth/AuthServiceImpl.java
+++ b/src/main/java/com/inssider/api/domains/auth/AuthServiceImpl.java
@@ -57,6 +57,8 @@ class AuthServiceImpl implements AuthService {
 
   @Override
   public void revokeRefreshToken(Account account) {
-    tokenService.revokeRefreshToken(account);
+    if (account != null) {
+      tokenService.revokeRefreshToken(account);
+    }
   }
 }

--- a/src/main/java/com/inssider/api/domains/auth/token/AuthTokenService.java
+++ b/src/main/java/com/inssider/api/domains/auth/token/AuthTokenService.java
@@ -2,7 +2,6 @@ package com.inssider.api.domains.auth.token;
 
 import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.auth.AuthResponsesDto.AuthTokenResponse;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 
 public interface AuthTokenService {
@@ -16,16 +15,13 @@ public interface AuthTokenService {
    * 계정의 Refresh Token을 무효화합니다.
    *
    * @param account 토큰을 무효화할 계정
-   * @throws NullPointerException account가 null인 경우
-   * @throws IllegalArgumentException 계정에 Refresh Token이 없는 경우
    */
-  void revokeRefreshToken(Account account) throws NullPointerException, IllegalArgumentException;
+  void revokeRefreshToken(Account account);
 
   /**
    * 토큰 문자열을 사용하여 해당 Refresh Token을 무효화합니다.
    *
    * @param token 무효화할 Refresh Token 문자열
-   * @throws NoSuchElementException 토큰과 연관된 계정을 찾을 수 없는 경우
    */
-  void revokeRefreshToken(String token) throws NullPointerException, IllegalArgumentException;
+  void revokeRefreshToken(String token);
 }

--- a/src/main/java/com/inssider/api/domains/profile/UserProfileController.java
+++ b/src/main/java/com/inssider/api/domains/profile/UserProfileController.java
@@ -5,6 +5,7 @@ import com.inssider.api.common.response.BaseResponse.ResponseWrapper;
 import com.inssider.api.common.response.StandardResponse.GetIndexResponse;
 import com.inssider.api.common.response.StandardResponse.QueryResponse;
 import com.inssider.api.domains.account.Account;
+import com.inssider.api.domains.profile.UserProfileDataTypes.ProfileContext;
 import com.inssider.api.domains.profile.UserProfileRequestsDto.PatchProfileMeRequest;
 import com.inssider.api.domains.profile.UserProfileResponsesDto.GetPrivateProfileResponse;
 import com.inssider.api.domains.profile.UserProfileResponsesDto.GetProfileMeResponse;
@@ -48,7 +49,7 @@ class UserProfileController {
 
   @GetMapping("/{id}")
   ResponseEntity<ResponseWrapper<GetProfileResponse>> getProfile(@PathVariable("id") Long id) {
-    var profileData = service.findUserProfileById(id);
+    var profileData = service.findUserProfileById(id, ProfileContext.PUBLIC);
     return switch (profileData) {
       case GetPublicProfileResponse pub -> BaseResponse.of(200, pub);
       case GetPrivateProfileResponse priv -> BaseResponse.of(200, priv);
@@ -59,8 +60,9 @@ class UserProfileController {
   @GetMapping("/me")
   ResponseEntity<ResponseWrapper<GetProfileMeResponse>> getProfile(
       @AuthenticationPrincipal Account account) {
-    var profileData = service.findUserProfileById(account.getId());
-    return switch (profileData) {
+    long accountId = account.getId();
+    GetProfileResponse data = service.findUserProfileById(accountId, ProfileContext.SELF);
+    return switch (data) {
       case GetProfileMeResponse owner -> BaseResponse.of(200, owner);
       default -> BaseResponse.of(403, null);
     };

--- a/src/main/java/com/inssider/api/domains/profile/UserProfileService.java
+++ b/src/main/java/com/inssider/api/domains/profile/UserProfileService.java
@@ -1,6 +1,7 @@
 package com.inssider.api.domains.profile;
 
 import com.inssider.api.common.response.StandardResponse.QueryResponse;
+import com.inssider.api.domains.profile.UserProfileDataTypes.ProfileContext;
 import com.inssider.api.domains.profile.UserProfileResponsesDto.GetProfileResponse;
 import com.inssider.api.domains.profile.UserProfileResponsesDto.PatchProfileMeResponse;
 import java.util.List;
@@ -13,7 +14,7 @@ public interface UserProfileService {
 
   long count();
 
-  GetProfileResponse findUserProfileById(Long id);
+  GetProfileResponse findUserProfileById(Long id, ProfileContext context);
 
   PatchProfileMeResponse updateUserProfile(
       Long id,

--- a/src/main/java/com/inssider/api/domains/profile/UserProfileServiceImpl.java
+++ b/src/main/java/com/inssider/api/domains/profile/UserProfileServiceImpl.java
@@ -1,6 +1,7 @@
 package com.inssider.api.domains.profile;
 
 import com.inssider.api.common.response.StandardResponse.QueryResponse;
+import com.inssider.api.domains.profile.UserProfileDataTypes.ProfileContext;
 import com.inssider.api.domains.profile.UserProfileResponsesDto.GetProfileResponse;
 import com.inssider.api.domains.profile.UserProfileResponsesDto.PatchProfileMeResponse;
 import java.util.List;
@@ -27,9 +28,9 @@ class UserProfileServiceImpl implements UserProfileService {
   }
 
   @Override
-  public GetProfileResponse findUserProfileById(Long id) {
+  public GetProfileResponse findUserProfileById(Long id, ProfileContext context) {
     UserProfile entity = repository.findById(id).orElseThrow();
-    return entity.convertToDto();
+    return entity.convertToDto(context);
   }
 
   @Override
@@ -51,7 +52,8 @@ class UserProfileServiceImpl implements UserProfileService {
 
     entity = repository.save(entity);
 
-    return new PatchProfileMeResponse(findUserProfileById(id), entity.getUpdatedAt());
+    return new PatchProfileMeResponse(
+        findUserProfileById(id, ProfileContext.SELF), entity.getUpdatedAt());
   }
 
   @Override

--- a/src/test/java/com/inssider/api/common/TestScenarioHelper.java
+++ b/src/test/java/com/inssider/api/common/TestScenarioHelper.java
@@ -156,7 +156,7 @@ public class TestScenarioHelper {
     Instant now = Instant.now();
     JwtClaimsSet claims =
         JwtClaimsSet.builder()
-            .issuer("api.inssider.com")
+            .issuer("https://inssider.oomia.click")
             .issuedAt(now)
             .audience(List.of("inssider-app"))
             .subject(String.valueOf(accountId))
@@ -171,10 +171,10 @@ public class TestScenarioHelper {
     Instant now = Instant.now();
     JwtClaimsSet claims =
         JwtClaimsSet.builder()
-            .issuer("api.inssider.com")
+            .claim("email", email)
+            .issuer("https://inssider.oomia.click")
             .issuedAt(now)
             .audience(List.of("inssider-app"))
-            .claim("email", email)
             .expiresAt(now.plus(600, ChronoUnit.SECONDS))
             .claim("type", "single_access")
             .id(UUID.randomUUID().toString())

--- a/src/test/java/com/inssider/api/common/TestScenarioHelper.java
+++ b/src/test/java/com/inssider/api/common/TestScenarioHelper.java
@@ -1,7 +1,6 @@
 package com.inssider.api.common;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -60,7 +59,6 @@ public class TestScenarioHelper {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().is2xxSuccessful())
-            .andDo(print())
             .andReturn()
             .getResponse()
             .getContentAsString();
@@ -176,7 +174,7 @@ public class TestScenarioHelper {
             .issuer("api.inssider.com")
             .issuedAt(now)
             .audience(List.of("inssider-app"))
-            .subject(email)
+            .claim("email", email)
             .expiresAt(now.plus(600, ChronoUnit.SECONDS))
             .claim("type", "single_access")
             .id(UUID.randomUUID().toString())

--- a/src/test/java/com/inssider/api/domains/profile/UserProfileControllerTests.java
+++ b/src/test/java/com/inssider/api/domains/profile/UserProfileControllerTests.java
@@ -1,0 +1,69 @@
+package com.inssider.api.domains.profile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.inssider.api.common.TestScenarioHelper;
+import com.inssider.api.common.Util;
+import com.inssider.api.domains.account.Account;
+import com.inssider.api.domains.account.AccountDataTypes.RegisterType;
+import com.inssider.api.domains.account.AccountService;
+import com.inssider.api.domains.profile.UserProfileResponsesDto.GetProfileMeResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestScenarioHelper.class)
+public class UserProfileControllerTests {
+  @Autowired private TestScenarioHelper helper;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private MockMvc mockMvc;
+  @Autowired private JwtDecoder jwtDecoder;
+
+  @Autowired private AccountService accountService;
+
+  @Test
+  @Transactional
+  void 프로필_조회() throws Exception {
+    // given
+    Account account = Util.accountGenerator().get();
+    String email = account.getEmail();
+    String password = account.getPassword();
+    account = accountService.register(RegisterType.PASSWORD, email, password);
+    assertEquals(1, account.getId());
+
+    String accessToken = helper.postAuthTokenWithPassword(email, password).accessToken();
+    var jwt = jwtDecoder.decode(accessToken);
+    assertEquals("1", jwt.getSubject());
+
+    // when
+    GetProfileMeResponse response;
+    {
+      var rawResponse =
+          mockMvc
+              .perform(
+                  get("/api/profiles/me")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .header("Authorization", "Bearer " + accessToken))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+      var data = objectMapper.readTree(rawResponse).get("data");
+      response = objectMapper.treeToValue(data, GetProfileMeResponse.class);
+    }
+
+    // then
+    assert response != null;
+  }
+}

--- a/src/test/java/com/inssider/api/domains/profile/UserProfileEntityBehaviorTests.java
+++ b/src/test/java/com/inssider/api/domains/profile/UserProfileEntityBehaviorTests.java
@@ -7,6 +7,7 @@ import com.inssider.api.common.Util;
 import com.inssider.api.domains.account.Account;
 import com.inssider.api.domains.account.AccountDataTypes.RegisterType;
 import com.inssider.api.domains.account.AccountService;
+import com.inssider.api.domains.profile.UserProfileDataTypes.ProfileContext;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +25,8 @@ class UserProfileEntityBehaviorTests {
   void 사용자프로필_저장_및_조회() {
     Account account = register(Util.accountGenerator().get());
     UserProfile userProfile = account.getProfile();
-    String profileNickname = service.findUserProfileById(account.getId()).nickname();
+    String profileNickname =
+        service.findUserProfileById(account.getId(), ProfileContext.SELF).nickname();
 
     assertNotNull(userProfile);
     assertEquals(account, userProfile.getAccount());
@@ -36,7 +38,6 @@ class UserProfileEntityBehaviorTests {
   void 계정_소프트_삭제시_프로필도_소프트_삭제되어야_한다() {
     Account account = register(Util.accountGenerator().get());
     Long accountId = account.getId();
-    service.findUserProfileById(accountId); // 프로필 조회
 
     accountService.softDelete(accountId); // 계정 삭제
 


### PR DESCRIPTION
회원가입된 계정에 대한 이메일/패스워드 로그인으로 발급받은 토큰이 정상적으로 사용 가능해집니다.

다음 시나리오에 대해 모든 요청이 정상적으로 수행되는 것을 확인했습니다.
1. POST /api/auth/email/challenge 이메일 인증 챌린지 요청
2. POST /api/auth/email/verify 이메일 인증 코드 검증
3. POST /api/auth/token 토큰 발급 (인가 코드 방식)
4. POST /api/accounts 계정 생성
5. POST /api/auth/token 토큰 발급 (패스워드 방식)
6. GET /api/profiles/me 프로필 정보 조회
7. PATCH /api/profiles/me 프로필 정보 수정
8. PATCH /api/accounts/me/password 계정 비밀번호 변경
9. POST /api/auth/token 토큰 발급 (패스워드 방식)